### PR TITLE
buffer overflow fix

### DIFF
--- a/cc1101-tool-esp32-wroom.ino
+++ b/cc1101-tool-esp32-wroom.ino
@@ -955,7 +955,7 @@ static void exec(char *cmdline)
                bigrecordingbufferpos = 0;
                // flush buffer for recording 
                for (int i = 0; i < RECORDINGBUFFERSIZE; i++)
-                    { bigrecordingbuffer[RECORDINGBUFFERSIZE] = 0; };
+                    { bigrecordingbuffer[i] = 0; };
                recordingmode = 1;
                jammingmode = 0;
                receivingmode = 0;


### PR DESCRIPTION
on ESP32-WROOM I get this sometimes depending on package size:

cc1101 initialized. Connection OK
rx 1

Receiving and printing RF packet changed to Enabled
rec 1

Recording mode set to Enabled
show

Frames stored in the recording buffer:
Frame 1 : 2010AABBCC
Frame 2 : 1010AABBCC

Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.

Core  1 register dump:

PC      : 0x400892bc  PS      : 0x00060e30  A0      : 0x800d687b  A1      : 0x3ffb2170  
A2      : 0x0000003f  A3      : 0xffffffff  A4      : 0x0000003f  A5      : 0x00000000  
A6      : 0x3ffb8cbc  A7      : 0x00000000  A8      : 0x80088e08  A9      : 0x3ffb2150  
A10     : 0x3ffc3510  A11     : 0x00000000  A12     : 0x00000000  A13     : 0x00000001  
A14     : 0x00060e20  A15     : 0x00000001  SAR     : 0x00000013  EXCCAUSE: 0x0000001c  
EXCVADDR: 0x0000007f  LBEG    : 0x400d67cd  LEND    : 0x400d67dc  LCOUNT  : 0x00000000  

Backtrace: 0x400892b9:0x3ffb2170 0x400d6878:0x3ffb21b0 0x400d4d58:0x3ffb21d0 0x400d33e9:0x3ffb21f0 0x400d4758:0x3ffb2210 0x400d306f:0x3ffb2240 0x400d7eb1:0x3ffb2290

Turns out, that the problem is a classic "buffer overflow" bug. When you run the rec command to enable recording mode, the code attempts to clear out the bigrecordingbuffer. However, it does so incorrectly.

The variable i loops from 0 to 4095, but inside the loop, the code always writes to bigrecordingbuffer[4096]. Since the buffer's valid indices are 0 to 4095, this code repeatedly writes a zero to a memory location that is one byte past the end of the buffer.

This overwrites and corrupts whatever data or system variable happens to be in memory right after bigrecordingbuffer, creating a "time bomb" that causes a crash later.

fix is : 

FROM:   
   bigrecordingbuffer[RECORDINGBUFFERSIZE] = 0; 

TO:
   bigrecordingbuffer[i] = 0;
 
 
 Thank you for this tool.  very handy for research.